### PR TITLE
Remove encoding of backslashes in precomputed asset URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@niaid/neuroglancer",
   "description": "Visualization tool for 3-D volumetric data.",
   "license": "Apache-2.0",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "main": "dist/module/main_module.js",
   "repository": {
     "type": "git",

--- a/src/neuroglancer/datasource/precomputed/backend.ts
+++ b/src/neuroglancer/datasource/precomputed/backend.ts
@@ -263,15 +263,11 @@ chunkDecoders.set(VolumeChunkEncoding.COMPRESSED_SEGMENTATION, decodeCompressedS
         // computeChunkBounds.
         let chunkPosition = this.computeChunkBounds(chunk);
         let chunkDataSize = chunk.chunkDataSize!;
-        url = `${parameters.url}%5C${chunkPosition[0]}-${chunkPosition[0] + chunkDataSize[0]}_` +
+        url = `${parameters.url}/${chunkPosition[0]}-${chunkPosition[0] + chunkDataSize[0]}_` +
             `${chunkPosition[1]}-${chunkPosition[1] + chunkDataSize[1]}_` +
             `${chunkPosition[2]}-${chunkPosition[2] + chunkDataSize[2]}`;
       }
-      const headers = new Headers();
-      headers.set('Authorization', `Bearer ${this.parameters.access_token}`);
-      let ri: RequestInit = {};
-      ri.headers = headers;      
-      response = await cancellableFetchSpecialOk(url, ri, responseArrayBuffer, cancellationToken);
+      response = await cancellableFetchSpecialOk(url, {}, responseArrayBuffer, cancellationToken);
     } else {
       this.computeChunkBounds(chunk);
       const {gridShape} = this;

--- a/src/neuroglancer/datasource/precomputed/base.ts
+++ b/src/neuroglancer/datasource/precomputed/base.ts
@@ -28,7 +28,6 @@ export class VolumeChunkSourceParameters {
   url: string;
   encoding: VolumeChunkEncoding;
   sharding: ShardingParameters|undefined;
-  access_token:string;
 
   static RPC_ID = 'precomputed/VolumeChunkSource';
 }

--- a/src/neuroglancer/datasource/precomputed/frontend.ts
+++ b/src/neuroglancer/datasource/precomputed/frontend.ts
@@ -231,10 +231,9 @@ class PrecomputedMultiscaleVolumeChunkSource extends MultiscaleVolumeChunkSource
                  chunkSource: this.chunkManager.getChunkSource(PrecomputedVolumeChunkSource, {
                    spec,
                    parameters: {
-                     url: this.url + "%5C" + scaleInfo.key,
+                     url: resolvePath(this.url, scaleInfo.key),
                      encoding: scaleInfo.encoding,
                      sharding: scaleInfo.sharding,
-                     access_token: window.sessionStorage['access_token'],
                    }
                  }),
                  chunkToMultiscaleTransform,
@@ -460,12 +459,7 @@ async function getSkeletonSource(chunkManager: ChunkManager, url: string) {
 
 function getJsonMetadata(chunkManager: ChunkManager, url: string): Promise<any> {
   return chunkManager.memoize.getUncounted({'type': 'precomputed:metadata', url}, async () => {
-    const headers = new Headers();
-    const token = window.sessionStorage['access_token'];
-    headers.set('Authorization', `Bearer ${token}`);
-    let ri: RequestInit = {};
-    ri.headers = headers;
-    const response = await fetchSpecialOk(`${url}%5Cinfo`, ri);
+    const response = await fetchSpecialOk(`${url}/info`);
     return response.json();
   });
 }


### PR DESCRIPTION
This PR reverts 452af81f0e49577b38542549285dfde6682d2a07. That commit was needed because Hedwig 1 API needed encoding of backslashes to work. This is not necessary anymore in Hedwig 2.