### PR TITLE
Add 2D layout that shows only XY view

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@niaid/neuroglancer",
   "description": "Visualization tool for 3-D volumetric data.",
   "license": "Apache-2.0",
-  "version": "2.18.0",
+  "version": "2.19.0",
   "main": "dist/module/main_module.js",
   "repository": {
     "type": "git",

--- a/src/neuroglancer/data_panel_layout.ts
+++ b/src/neuroglancer/data_panel_layout.ts
@@ -89,6 +89,7 @@ const oneSquareSymbol = '◻';
 const LAYOUT_SYMBOLS = new Map<string, string>([
   ['4panel', '◱'],
   ['3d', oneSquareSymbol],
+  ['2d', '2D'],
 ]);
 
 export function makeSliceView(viewerState: SliceViewViewerState, baseToSelf?: quat) {
@@ -433,6 +434,12 @@ export const LAYOUTS = new Map<string, {
         '3d', {
           factory: (container, element, viewer, crossSections) =>
               new SinglePerspectiveLayout(container, element, viewer, crossSections)
+        }
+      ],
+      [
+        '2d', {
+          factory: (container, element, viewer) =>
+            new SinglePanelLayout(container, element, viewer, "xy")
         }
       ],
     ],


### PR DESCRIPTION
- Create a new layout (`2d`) that only contains one panel that shows XY slice.
![Screen Shot 2023-03-17 at 4 01 13 PM](https://user-images.githubusercontent.com/7352279/226019938-da74453a-ab5b-49a8-8f15-eed18dd5d302.png)
