### PR TITLE
Enable hiding of z scale bar 

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@niaid/neuroglancer",
   "description": "Visualization tool for 3-D volumetric data.",
   "license": "Apache-2.0",
-  "version": "2.22.0",
+  "version": "2.23.0",
   "main": "dist/module/main_module.js",
   "repository": {
     "type": "git",

--- a/src/main_module.ts
+++ b/src/main_module.ts
@@ -23,6 +23,7 @@ export const hedwigSetup = (options: {
   target: HTMLElement | undefined,
   bundleRoot: string | undefined,
   chunkWorkerFileName: string,
+  hedwigHideZScaleBar: boolean 
 }) => {
 
   registerPositionWidgetTool()
@@ -31,6 +32,7 @@ export const hedwigSetup = (options: {
   disableWheel();
   let viewer = makeMinimalViewer({
     chunkWorkerFileName: options.chunkWorkerFileName,
+    hedwigHideZScaleBar: options.hedwigHideZScaleBar,
   }, options.target);
   setDefaultInputEventBindings(viewer.inputEventBindings);
   bindDefaultCopyHandler(viewer);

--- a/src/neuroglancer/data_panel_layout.ts
+++ b/src/neuroglancer/data_panel_layout.ts
@@ -63,6 +63,7 @@ export interface ViewerUIState extends SliceViewViewerState, VisibilityPriorityS
   showAxisLines: TrackableBoolean;
   wireFrame: TrackableBoolean;
   showScaleBar: TrackableBoolean;
+  hedwigHideZScaleBar: TrackableBoolean
   scaleBarOptions: TrackableValue<ScaleBarOptions>;
   visibleLayerRoles: WatchableSet<RenderLayerRole>;
   selectedLayer: SelectedLayerState;
@@ -264,11 +265,13 @@ export class FourPanelLayout extends RefCounted {
     const sliceViewerState = {
       ...getCommonSliceViewerState(viewer),
       showScaleBar: viewer.showScaleBar,
+      hedwigHideZScaleBar: viewer.hedwigHideZScaleBar,
     };
 
     const sliceViewerStateWithoutScaleBar = {
       ...getCommonSliceViewerState(viewer),
       showScaleBar: new TrackableBoolean(false, false),
+      hedwigHideZScaleBar: new TrackableBoolean(false, false),
     };
 
     const makeSliceViewPanel =
@@ -337,6 +340,7 @@ export class SliceViewPerspectiveTwoPanelLayout extends RefCounted {
     const sliceViewerState = {
       ...getCommonSliceViewerState(viewer),
       showScaleBar: viewer.showScaleBar,
+      hedwigHideZScaleBar: viewer.hedwigHideZScaleBar,
     };
 
     L.withFlex(1, L.box(direction, [
@@ -376,6 +380,7 @@ export class SinglePanelLayout extends RefCounted {
     const sliceViewerState = {
       ...getCommonSliceViewerState(viewer),
       showScaleBar: viewer.showScaleBar,
+      hedwigHideZScaleBar: viewer.hedwigHideZScaleBar,
     };
 
     L.box('row', [L.withFlex(1, element => {

--- a/src/neuroglancer/layer_group_viewer.ts
+++ b/src/neuroglancer/layer_group_viewer.ts
@@ -55,6 +55,7 @@ export interface LayerGroupViewerState {
   showAxisLines: TrackableBoolean;
   wireFrame: TrackableBoolean;
   showScaleBar: TrackableBoolean;
+  hedwigHideZScaleBar: TrackableBoolean
   scaleBarOptions: TrackableScaleBarOptions;
   showPerspectiveSliceViews: TrackableBoolean;
   layerSpecification: Owned<LayerListSpecification>;
@@ -267,6 +268,9 @@ export class LayerGroupViewer extends RefCounted {
   }
   get showScaleBar() {
     return this.viewerState.showScaleBar;
+  }
+  get hedwigHideZScaleBar() {
+    return this.viewerState.hedwigHideZScaleBar;
   }
   get showPerspectiveSliceViews() {
     return this.viewerState.showPerspectiveSliceViews;

--- a/src/neuroglancer/layer_groups_layout.ts
+++ b/src/neuroglancer/layer_groups_layout.ts
@@ -312,6 +312,7 @@ function getCommonViewerState(viewer: Viewer) {
     showAxisLines: viewer.showAxisLines,
     wireFrame: viewer.wireFrame,
     showScaleBar: viewer.showScaleBar,
+    hedwigHideZScaleBar: viewer.hedwigHideZScaleBar,
     scaleBarOptions: viewer.scaleBarOptions,
     showPerspectiveSliceViews: viewer.showPerspectiveSliceViews,
     inputEventBindings: viewer.inputEventBindings,

--- a/src/neuroglancer/perspective_view/panel.ts
+++ b/src/neuroglancer/perspective_view/panel.ts
@@ -194,7 +194,7 @@ export class PerspectivePanel extends RenderedDataPanel {
 
   private sharedObject: PerspectiveViewState;
 
-  private scaleBars = this.registerDisposer(new MultipleScaleBarTextures(this.gl));
+  private scaleBars = this.registerDisposer(new MultipleScaleBarTextures(this.gl, false));
 
   flushBackendProjectionParameters() {
     this.sharedObject.sharedProjectionParameters.flush();

--- a/src/neuroglancer/sliceview/panel.ts
+++ b/src/neuroglancer/sliceview/panel.ts
@@ -34,6 +34,7 @@ import {MultipleScaleBarTextures, TrackableScaleBarOptions} from 'neuroglancer/w
 
 export interface SliceViewerState extends RenderedDataViewerState {
   showScaleBar: TrackableBoolean;
+  hedwigHideZScaleBar: TrackableBoolean
   wireFrame: TrackableBoolean;
   scaleBarOptions: TrackableScaleBarOptions;
   crossSectionBackgroundColor: TrackableRGB;
@@ -110,7 +111,7 @@ export class SliceViewPanel extends RenderedDataPanel {
   }));
 
   private offscreenCopyHelper = this.registerDisposer(OffscreenCopyHelper.get(this.gl));
-  private scaleBars = this.registerDisposer(new MultipleScaleBarTextures(this.gl));
+  private scaleBars = this.registerDisposer(new MultipleScaleBarTextures(this.gl, this.viewer.hedwigHideZScaleBar.value));
 
   get navigationState() {
     return this.sliceView.navigationState;
@@ -170,6 +171,11 @@ export class SliceViewPanel extends RenderedDataPanel {
     }));
 
     this.registerDisposer(viewer.showScaleBar.changed.add(() => {
+      if (this.visible) {
+        this.context.scheduleRedraw();
+      }
+    }));
+    this.registerDisposer(viewer.hedwigHideZScaleBar.changed.add(() => {
       if (this.visible) {
         this.context.scheduleRedraw();
       }

--- a/src/neuroglancer/viewer.ts
+++ b/src/neuroglancer/viewer.ts
@@ -162,6 +162,7 @@ export interface ViewerOptions extends ViewerUIOptions, VisibilityPrioritySpecif
   inputEventBindings: InputEventBindings;
   resetStateWhenEmpty: boolean;
   chunkWorkerFileName: string;
+  hedwigHideZScaleBar: boolean
 }
 
 const defaultViewerOptions = 'undefined' !== typeof NEUROGLANCER_OVERRIDE_DEFAULT_VIEWER_OPTIONS ?
@@ -190,6 +191,7 @@ class TrackableViewerState extends CompoundTrackable {
     this.add('showAxisLines', viewer.showAxisLines);
     this.add('wireFrame', viewer.wireFrame);
     this.add('showScaleBar', viewer.showScaleBar);
+    this.add('hedwigHideZScaleBar', viewer.hedwigHideZScaleBar);
     this.add('showDefaultAnnotations', viewer.showDefaultAnnotations);
 
     this.add('showSlices', viewer.showPerspectiveSliceViews);
@@ -288,6 +290,7 @@ export class Viewer extends RefCounted implements ViewerState {
   showAxisLines = new TrackableBoolean(true, true);
   wireFrame = new TrackableBoolean(false, false);
   showScaleBar = new TrackableBoolean(true, true);
+  hedwigHideZScaleBar = new TrackableBoolean(false, false);
   showPerspectiveSliceViews = new TrackableBoolean(true, true);
   visibleLayerRoles = allRenderLayerRoles();
   showDefaultAnnotations = new TrackableBoolean(true, true);
@@ -353,6 +356,10 @@ export class Viewer extends RefCounted implements ViewerState {
 
   constructor(public display: DisplayContext, options: Partial<ViewerOptions> = {}) {
     super();
+
+    if (options.hedwigHideZScaleBar === true) {
+      this.hedwigHideZScaleBar.value = options.hedwigHideZScaleBar
+    }
 
     const {
       dataContext = new DataManagementContext(display.gl, display, options.chunkWorkerFileName),

--- a/src/neuroglancer/widget/scale_bar.ts
+++ b/src/neuroglancer/widget/scale_bar.ts
@@ -245,7 +245,7 @@ export class MultipleScaleBarTextures extends RefCounted {
   private scaleBarCopyHelper = this.registerDisposer(OffscreenCopyHelper.get(this.gl));
   private scaleBars: ScaleBarTexture[] = [];
 
-  constructor(public gl: GL) {
+  constructor(public gl: GL, public hedwigHideZScaleBar: boolean) {
     super();
     for (let i = 0; i < 3; ++i) {
       this.scaleBars.push(this.registerDisposer(new ScaleBarTexture(gl)));
@@ -320,7 +320,10 @@ export class MultipleScaleBarTextures extends RefCounted {
               (1 - (viewport.visibleTopFraction + viewport.visibleHeightFraction)) *
                   viewport.logicalHeight,
           scaleBar.width, scaleBar.height);
-      scaleBarCopyHelper.draw(scaleBar.texture);
+      if (this.hedwigHideZScaleBar !== true || scaleBar.label !== "z : ") {
+        scaleBarCopyHelper.draw(scaleBar.texture);
+      }
+
       bottomPixelOffset +=
           scaleBar.height + options.marginPixelsBetweenScaleBars * options.scaleFactor;
     }


### PR DESCRIPTION
- Add an option to the viewer called `hedwigHideZScaleBar` that hides the z scale bar (but leaves the xy scale bar alone) in 2D view.